### PR TITLE
Feature/use shift label to display shift transfer details

### DIFF
--- a/Kronos-Shifts-Connector/Deployment/azuredeploy.json
+++ b/Kronos-Shifts-Connector/Deployment/azuredeploy.json
@@ -1,820 +1,864 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "baseResourceName": {
-            "type": "string",
-            "minLength": 1,
-            "metadata": {
-                "description": "The base name to use for the resources that will be provisioned."
-            }
-        },
-        "aadAppClientId": {
-            "type": "string",
-            "minLength": 36,
-            "maxLength": 36,
-            "metadata": {
-                "description": "The Microsoft Application ID for the Shifts-Kronos Integration instance, e.g., 123e4567-e89b-12d3-a456-426655440000."
-            }
-        },
-        "aadAppClientSecret": {
-            "type": "securestring",
-            "minLength": 1,
-            "metadata": {
-                "description": "The Microsoft Application Password for the Shifts-Kronos Integration."
-            }
-        },
-        "managedAadAppObjectId": {
-            "type": "string",
-            "minLength": 1,
-            "metadata": {
-                "description": "The Microsoft Application Object ID for the Shifts-Kronos Integration."
-            }
-        },
-        "teamsTenantId": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 36,
-            "metadata": {
-                "description": "The Microsoft Teams Tenant ID."
-            }
-        },
-        "firstTimeSyncStartDate": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 10,
-            "defaultValue": "[utcNow('d')]",
-            "metadata": {
-                "description": "The start date for the sync of all data from Kronos and should be written in the MM/DD/YYYY format."
-            }
-        },
-        "firstTimeSyncEndDate": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 10,
-            "defaultValue": "[utcNow('d')]",
-            "metadata": {
-                "description": "The start date for the sync of all data from Kronos and should be written in the MM/DD/YYYY format."
-            }
-        },
-        "location": {
-            "type": "string",
-            "defaultValue": "[resourceGroup().location]",
-            "metadata": {
-                "description": "Location for all resources"
-            }
-        },
-        "storageAccountType": {
-            "type": "string",
-            "defaultValue": "Standard_LRS",
-            "allowedValues": [
-                "Standard_LRS",
-                "Standard_GRS",
-                "Standard_ZRS",
-                "Premium_LRS"
-            ],
-            "metadata": {
-                "description": "Storage Account type"
-            }
-        },
-        "sku": {
-            "type": "string",
-            "allowedValues": [
-                "Basic",
-                "Standard",
-                "Premium"
-            ],
-            "defaultValue": "Standard",
-            "metadata": {
-                "description": "The pricing tier for the hosting plan."
-            }
-        },
-        "planSize": {
-            "type": "string",
-            "allowedValues": [
-                "1",
-                "2",
-                "3"
-            ],
-            "defaultValue": "1",
-            "metadata": {
-                "description": "The size of the hosting plan (small, medium, or large)."
-            }
-        },
-        "processNumberOfUsersInBatch": {
-            "type": "int",
-            "defaultValue": 100,
-            "metadata": {
-                "description": "The number of users to process in a batch manner when syncing the Shifts from Kronos to Shifts."
-            }
-        },
-        "processNumberOfOrgJobsInBatch": {
-            "type": "int",
-            "defaultValue": 50,
-            "metadata": {
-                "description": "The number of Kronos Org Job Paths to process in a batch manner when syncing the Open Shifts from Kronos to Shifts."
-            }
-        },
-        "syncFromPreviousDays": {
-            "type": "int",
-            "defaultValue": 7,
-            "metadata": {
-                "description": "The number of days in the past to sync the data for the first time from Kronos to Shifts."
-            }
-        },
-        "syncToNextDays": {
-            "type": "int",
-            "defaultValue": 7,
-            "metadata": {
-                "description": "The number of days in the future to sync the data for the first time from Kronos to Shifts."
-            }
-        },
-        "correctDateSpanForOutboundCalls": {
-            "type": "int",
-            "defaultValue": 100,
-            "metadata": {
-                "description": "This value will be able to accommodate for any requests that FLWs make for Swap Shift Requests, or Open Shift Requests in the Shifts UI."
-            }
-        },
-        "kronosUserName": {
-            "type": "string",
-            "metadata": {
-                "description": "Please enter the Kronos WFC SuperUser name here."
-            }
-        },
-        "kronosPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Please enter the Kronos WFC SuperUser password here."
-            }
-        },
-        "gitRepoUrl": {
-            "type": "string",
-            "defaultValue": "https://github.com/OfficeDev/Microsoft-Teams-Shifts-WFM-Connectors"
-        },
-        "gitBranch": {
-            "type": "string",
-            "defaultValue": "master"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "baseResourceName": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "The base name to use for the resources that will be provisioned."
+      }
     },
-    "variables": {
-        "authority": "https://login.microsoftonline.com/common",
-        "storageAccountName": "[uniquestring(concat(resourceGroup().id, parameters('baseResourceName')))]",
-        "hostingPlanName": "[concat('shiftsKronos', uniqueString(resourceGroup().id))]",
-        "configAppName": "[concat(parameters('baseResourceName'), '-config')]",
-        "configAppUrl": "[concat('https://', variables('configAppName'), '.azurewebsites.net')]",
-        "configAppInsightsName": "[concat(parameters('baseResourceName'), '-config')]",
-        "apiAppName": "[concat(parameters('baseResourceName'), '-api')]",
-        "apiAppUrl": "[concat('https://', variables('apiAppName'), '.azurewebsites.net')]",
-        "apiAppInsightsName": "[concat(parameters('baseResourceName'), '-api')]",
-        "sharedSkus": [
-            "Free",
-            "Shared"
-        ],
-        "isSharedPlan": "[contains(variables('sharedSkus'), parameters('sku'))]",
-        "skuFamily": "[if(equals(parameters('sku'), 'Shared'), 'D', take(parameters('sku'), 1))]",
-        "keyVaultName": "[concat(parameters('baseResourceName'), '-azureKV')]",
-        "logicAppName": "[concat(parameters('baseResourceName'), '-logicApp')]",
-        "redisCacheName": "[concat(parameters('baseResourceName'), '-redis')]",
-        "CallbackPath": "/signin-oidc",
-        "SignedOutCallbackPath ": "/signout-callback-oidc",
-        "ResponseType": "code id_token",
-        "GraphApiUrlConfig": "https://graph.microsoft.com/beta/",
-        "TemplatesContainerName": "templates",
-        "KronosUserDetailsQuery": "All Home",
-        "KronosShiftUserMappingTemplateName": "KronosShiftUserMappingTemplate.xlsx",
-        "KronosShiftTeamDeptMappingTemplateName": "KronosShiftTeamDeptMappingTemplate.xlsx",
-        "ExcelContentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "kronosQueryDateSpanFormat": "MM/dd/yyyy",
-        "logicAppAudience": "[parameters('aadAppClientId')]",
-        "logicAppAuthenticationType": "ActiveDirectoryOAuth",
-        "keyVaultUrl": "[concat('https://', variables('keyVaultName'), '.vault.azure.net/')]"
+    "aadAppClientId": {
+      "type": "string",
+      "minLength": 36,
+      "maxLength": 36,
+      "metadata": {
+        "description": "The Microsoft Application ID for the Shifts-Kronos Integration instance, e.g., 123e4567-e89b-12d3-a456-426655440000."
+      }
     },
-    "resources": [
-        {
-            "type": "Microsoft.Cache/Redis",
-            "apiVersion": "2017-10-01",
-            "name": "[variables('redisCacheName')]",
-            "location": "[parameters('location')]",
-            "comments": "This Redis cache is used for caching the Graph API token.",
-            "properties": {
-                "sku": {
-                    "name": "Standard",
-                    "family": "C",
-                    "capacity": 1
-                },
-                "enableNonSslPort": false,
-                "redisConfiguration": {
-                    "maxclients": "1000",
-                    "maxmemory-reserved": "50",
-                    "maxfragmentationmemory-reserved": "50",
-                    "maxmemory-delta": "50"
-                }
-            }
-        },
-        {
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('storageAccountName')]",
-            "location": "[parameters('location')]",
-            "comments": "This storage account is used for storing mapping information, map entities between Kronos and Shifts, and store the templates blob.",
-            "apiVersion": "2018-02-01",
-            "sku": {
-                "name": "[parameters('storageAccountType')]"
-            },
-            "kind": "StorageV2",
-            "properties": {
-            },
-            "resources": [
-                {
-                    "name": "[concat('default/', variables('TemplatesContainerName'))]",
-                    "type": "blobServices/containers",
-                    "apiVersion": "2018-07-01",
-                    "dependsOn": [
-                        "[variables('storageAccountName')]"
-                    ]
-                }
-            ]
-        },
-        {
-            "type": "Microsoft.Web/serverfarms",
-            "apiVersion": "2016-09-01",
-            "name": "[variables('hostingPlanName')]",
-            "location": "[parameters('location')]",
-            "comments": "This hosting plan is used for hosting the Configuration Web app and the Integration Service API.",
-            "properties": {
-                "name": "[variables('hostingPlanName')]",
-                "hostingEnvironment": "",
-                "numberOfWorkers": 1
-            },
-            "sku": {
-                "name": "[if(variables('isSharedPlan'), concat(variables('skuFamily'),'1'), concat(variables('skuFamily'),parameters('planSize')))]",
-                "tier": "[parameters('sku')]",
-                "size": "[concat(variables('skuFamily'), parameters('planSize'))]",
-                "family": "[variables('skuFamily')]",
-                "capacity": 0
-            }
-        },
-        {
-            "type": "Microsoft.Insights/components",
-            "name": "[variables('configAppInsightsName')]",
-            "apiVersion": "2015-05-01",
-            "location": "[parameters('location')]",
-            "comments": "This ApplicationInsights resource tracks telemetry for the Configuration Web app.",
-            "kind": "",
-            "properties": {
-                "Application_Type": "web"
-            }
-        },
-        {
-            "type": "Microsoft.Insights/components",
-            "name": "[variables('apiAppInsightsName')]",
-            "apiVersion": "2015-05-01",
-            "location": "[parameters('location')]",
-            "comments": "This ApplicationInsights resource tracks telemetry for the Integration Service API.",
-            "kind": "",
-            "properties": {
-                "Application_Type": "web"
-            }
-        },
-        {
-            "type": "Microsoft.Web/sites",
-            "apiVersion": "2016-08-01",
-            "name": "[variables('configAppName')]",
-            "location": "[parameters('location')]",
-            "comments": "This Web App is the Configuration Web App.",
-            "kind": "app",
-            "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
-                "[resourceId('Microsoft.Insights/components/', variables('configAppInsightsName'))]",
-                "[resourceId('Microsoft.Cache/Redis', variables('redisCacheName'))]",
-                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
-            ],
-            "identity": {
-                "type": "SystemAssigned"
-            },
-            "properties": {
-                "name": "[variables('configAppName')]",
-                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "enabled": true,
-                "reserved": false,
-                "clientAffinityEnabled": true,
-                "clientCertEnabled": false,
-                "hostNamesDisabled": false,
-                "containerSize": 0,
-                "dailyMemoryTimeQuota": 0,
-                "httpsOnly": true,
-                "siteConfig": {
-                    "alwaysOn": true,
-                    "appSettings": [
-                        {
-                            "name": "DEPLOYMENT_SCRIPT",
-                            "value": "Kronos-Shifts-Connector/deploy.config.cmd"
-                        },
-                        {
-                            "name": "ASPNETCORE_DETAILEDERRORS",
-                            "value": true
-                        },
-                        {
-                            "name": "TenantId",
-                            "value": "[parameters('teamsTenantId')]"
-                        },
-                        {
-                            "name": "ClientId",
-                            "value": "[parameters('aadAppClientId')]"
-                        },
-                        {
-                            "name": "Authority",
-                            "value": "[variables('authority')]"
-                        },
-                        {
-                            "name": "CallbackPath",
-                            "value": "[variables('CallbackPath')]"
-                        },
-                        {
-                            "name": "SignedOutCallbackPath",
-                            "value": "[variables('SignedOutCallbackPath ')]"
-                        },
-                        {
-                            "name": "ClientSecret",
-                            "value": "ClientSecret"
-                        },
-                        {
-                            "name": "ResponseType",
-                            "value": "[variables('ResponseType')]"
-                        },
-                        {
-                            "name": "GraphApiUrl",
-                            "value": "[variables('GraphApiUrlConfig')]"
-                        },
-                        {
-                            "name": "StorageConnectionString",
-                            "value": "StorageConnectionString"
-                        },
-                        {
-                            "name": "RedisCacheConfiguration",
-                            "value": "RedisCacheConfiguration"
-                        },
-                        {
-                            "name": "RedisCacheInstanceName",
-                            "value": "[variables('redisCacheName')]"
-                        },
-                        {
-                            "name": "IntegrationApiUrl",
-                            "value": "[variables('apiAppUrl')]"
-                        },
-                        {
-                            "name": "BaseAddressFirstTimeSync",
-                            "value": "[concat(variables('apiAppUrl'), '/')]"
-                        },
-                        {
-                            "name": "KronosUserDetailsQuery",
-                            "value": "[variables('KronosUserDetailsQuery')]"
-                        },
-                        {
-                            "name": "TemplatesContainerName",
-                            "value": "[variables('TemplatesContainerName')]"
-                        },
-                        {
-                            "name": "KronosShiftUserMappingTemplateName",
-                            "value": "[variables('KronosShiftUserMappingTemplateName')]"
-                        },
-                        {
-                            "name": "KronosShiftTeamDeptMappingTemplateName",
-                            "value": "[variables('KronosShiftTeamDeptMappingTemplateName')]"
-                        },
-                        {
-                            "name": "ExcelContentType",
-                            "value": "[variables('ExcelContentType')]"
-                        },
-                        {
-                            "name": "WfmSuperUsername",
-                            "value": "WorkforceSuperUserName"
-                        },
-                        {
-                            "name": "WfmSuperUserPassword",
-                            "value": "WorkforceSuperUserPassword"
-                        },
-                        {
-                            "name": "KeyVault",
-                            "value": "[variables('keyVaultUrl')]"
-                        },
-                        {
-                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                            "value": "[reference(resourceId('Microsoft.Insights/components/', variables('configAppInsightsName')), '2015-05-01').InstrumentationKey]"
-                        },
-                        {
-                            "name": "principalId",
-                            "value": "[parameters('managedAadAppObjectId')]"
-                        }
-                    ]
-                }
-            },
-            "resources": [
-                {
-                    "apiVersion": "2020-12-01",
-                    "name": "web",
-                    "type": "sourcecontrols",
-                    "dependsOn": [
-                        "[concat('Microsoft.Web/sites/', variables('configAppName'))]"
-                    ],
-                    "properties": {
-                        "RepoUrl": "[parameters('gitRepoUrl')]",
-                        "branch": "[parameters('gitBranch')]",
-                        "IsManualIntegration": true
-                    }
-                }
-            ]
-        },
-        {
-            "type": "Microsoft.Web/sites",
-            "apiVersion": "2016-08-01",
-            "name": "[variables('apiAppName')]",
-            "location": "[parameters('location')]",
-            "comments": "This Web app is for the Integration Service API.",
-            "kind": "app",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
-                "[resourceId('Microsoft.Insights/components/', variables('apiAppInsightsName'))]",
-                "[resourceId('Microsoft.Cache/Redis', variables('redisCacheName'))]"
-            ],
-            "identity": {
-                "type": "SystemAssigned"
-            },
-            "properties": {
-                "name": "[variables('apiAppName')]",
-                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "enabled": true,
-                "reserved": false,
-                "clientAffinityEnabled": true,
-                "clientCertEnabled": false,
-                "hostNamesDisabled": false,
-                "containerSize": 0,
-                "dailyMemoryTimeQuota": 0,
-                "httpsOnly": true,
-                "siteConfig": {
-                    "alwaysOn": true,
-                    "appSettings": [
-                        {
-                            "name": "DEPLOYMENT_SCRIPT",
-                            "value": "Kronos-Shifts-Connector/deploy.api.cmd"
-                        },
-                        {
-                            "name": "ASPNETCORE_DETAILEDERRORS",
-                            "value": true
-                        },
-                        {
-                            "name": "GraphApiUrl",
-                            "value": "https://graph.microsoft.com"
-                        },
-                        {
-                            "name": "GraphBetaApiUrl",
-                            "value": "https://graph.microsoft.com/beta/"
-                        },
-                        {
-                            "name": "ShiftStartDate",
-                            "value": "[parameters('firstTimeSyncStartDate')]"
-                        },
-                        {
-                            "name": "ShiftEndDate",
-                            "value": "[parameters('firstTimeSyncEndDate')]"
-                        },
-                        {
-                            "name": "ShiftTheme",
-                            "value": "blue"
-                        },
-                        {
-                            "name": "OpenShiftTheme",
-                            "value": "green"
-                        },
-                        {
-                            "name": "Instance",
-                            "value": "https://login.microsoftonline.com/"
-                        },
-                        {
-                            "name": "TenantId",
-                            "value": "[parameters('teamsTenantId')]"
-                        },
-                        {
-                            "name": "KeyVault",
-                            "value": "[variables('keyVaultUrl')]"
-                        },
-                        {
-                            "name": "ProcessNumberOfUsersInBatch",
-                            "value": "[parameters('processNumberOfUsersInBatch')]"
-                        },
-                        {
-                            "name": "ProcessNumberOfOrgJobsInBatch",
-                            "value": "[parameters('processNumberOfOrgJobsInBatch')]"
-                        },
-                        {
-                            "name": "ShiftEntityMapping",
-                            "value": "ShiftEntityMapping"
-                        },
-                        {
-                            "name": "SwapShiftEntityMapping",
-                            "value": "SwapShiftEntityMapping"
-                        },
-                        {
-                            "name": "TeamDepartmentMapping",
-                            "value": "TeamToDepartmentWithJobMapping"
-                        },
-                        {
-                            "name": "UserToUserMapping",
-                            "value": "UserToUserMapping"
-                        },
-                        {
-                            "name": "WfmSuperUsername",
-                            "value": "WorkforceSuperUserName"
-                        },
-                        {
-                            "name": "WfmSuperUserPassword",
-                            "value": "WorkforceSuperUserPassword"
-                        },
-                        {
-                            "name": "ClientSecret",
-                            "value": "ClientSecret"
-                        },
-                        {
-                            "name": "StorageConnectionString",
-                            "value": "StorageConnectionString"
-                        },
-                        {
-                            "name": "RedisCacheConfiguration",
-                            "value": "RedisCacheConfiguration"
-                        },
-                        {
-                            "name": "RedisCacheInstanceName",
-                            "value": "[variables('redisCacheName')]"
-                        },
-                        {
-                            "name": "SyncFromPreviousDays",
-                            "value": "[parameters('syncFromPreviousDays')]"
-                        },
-                        {
-                            "name": "SyncToNextDays",
-                            "value": "[parameters('syncToNextDays')]"
-                        },
-                        {
-                            "name": "SyncDelayForPolling",
-                            "value": 0
-                        },
-                        {
-                            "name": "KronosQueryDateSpanFormat",
-                            "value": "[variables('kronosQueryDateSpanFormat')]"
-                        },
-                        {
-                            "name": "BaseAddressFirstTimeSync",
-                            "value": "[variables('apiAppUrl')]"
-                        },
-                        {
-                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                            "value": "[reference(resourceId('Microsoft.Insights/components/', variables('apiAppInsightsName')), '2015-05-01').InstrumentationKey]"
-                        },
-                        {
-                            "name": "principalId",
-                            "value": "[parameters('managedAadAppObjectId')]"
-                        },
-                        {
-                            "name": "CorrectedDateSpanForOutboundCalls",
-                            "value": "[parameters('correctDateSpanForOutboundCalls')]"
-                        },
-                        {
-                            "name": "ClientId",
-                            "value": "[parameters('aadAppClientId')]"
-                        }
-                    ]
-                }
-            },
-            "resources": [
-                {
-                    "apiVersion": "2020-12-01",
-                    "name": "web",
-                    "type": "sourcecontrols",
-                    "dependsOn": [
-                        "[concat('Microsoft.Web/sites/', variables('apiAppName'))]"
-                    ],
-                    "properties": {
-                        "RepoUrl": "[parameters('gitRepoUrl')]",
-                        "branch": "[parameters('gitBranch')]",
-                        "IsManualIntegration": true
-                    }
-                }
-            ]
-        },
-        {
-            "type": "Microsoft.KeyVault/vaults",
-            "apiVersion": "2018-02-14",
-            "name": "[variables('keyVaultName')]",
-            "location": "[parameters('location')]",
-            "comments": "This Azure KeyVault will store the necessary information like the Kronos credentials, etc.",
-            "dependsOn": [
-                "[concat('Microsoft.Web/sites/', variables('apiAppName'))]",
-                "[concat('Microsoft.Web/sites/', variables('configAppName'))]"
-            ],
-            "tags": {
-                "displayName": "KeyVault"
-            },
-            "properties": {
-                "enabledForDeployment": "false",
-                "enabledForTemplateDeployment": "false",
-                "enabledForDiskEncryption": "false",
-                "tenantId": "[subscription().tenantId]",
-                "accessPolicies": [
-                    {
-                        "objectId": "[reference(concat('Microsoft.Web/sites/', variables('apiAppName')), '2018-02-01', 'Full').identity.principalId]",
-                        "tenantId": "[subscription().tenantId]",
-                        "permissions": {
-                            "secrets": [
-                                "get"
-                            ]
-                        }
-                    },
-                    {
-                        "objectId": "[reference(concat('Microsoft.Web/sites/', variables('configAppName')), '2018-02-01', 'Full').identity.principalId]",
-                        "tenantId": "[subscription().tenantId]",
-                        "permissions": {
-                            "secrets": [
-                                "get", "delete", "set"
-                            ]
-                        }
-                    }
-                ],
-                "sku": {
-                    "name": "Standard",
-                    "family": "A"
-                },
-                "networkAcls": {
-                    "value": {
-                        "defaultAction": "Allow",
-                        "bypass": "AzureServices"
-                    }
-                }
-            }
-        },
-        {
-            "type": "Microsoft.KeyVault/vaults/secrets",
-            "apiVersion": "2016-10-01",
-            "name": "[concat(variables('keyVaultName'), '/ClientId')]",
-            "comments": "This secret is for the ClientID, or the Azure AD Application ID.",
-            "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
-            ],
-            "properties": {
-                "attributes": {
-                    "enabled": true
-                },
-                "value": "[parameters('aadAppClientId')]"
-            }
-        },
-        {
-            "type": "Microsoft.KeyVault/vaults/secrets",
-            "apiVersion": "2016-10-01",
-            "name": "[concat(variables('keyVaultName'), '/ClientSecret')]",
-            "comments": "This secret is for the ClientSecret which is for the Azure AD Application Registration.",
-            "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
-            ],
-            "properties": {
-                "attributes": {
-                    "enabled": true
-                },
-                "value": "[parameters('aadAppClientSecret')]"
-            }
-        },
-        {
-            "type": "Microsoft.KeyVault/vaults/secrets",
-            "apiVersion": "2016-10-01",
-            "name": "[concat(variables('keyVaultName'), '/RedisCacheConfiguration')]",
-            "comments": "This secret is for the Redis Cache configuration.",
-            "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
-            ],
-            "properties": {
-                "attributes": {
-                    "enabled": true
-                },
-                "value": "[concat(variables('redisCacheName'),'.redis.cache.windows.net,abortConnect=false,ssl=true,password=', listKeys(resourceId('Microsoft.Cache/Redis', variables('redisCacheName')), '2015-08-01').primaryKey)]"
-            }
-        },
-        {
-            "type": "Microsoft.KeyVault/vaults/secrets",
-            "apiVersion": "2016-10-01",
-            "name": "[concat(variables('keyVaultName'), '/StorageConnectionString')]",
-            "comments": "This secret is the Azure Table storage connection string.",
-            "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
-            ],
-            "properties": {
-                "attributes": {
-                    "enabled": true
-                },
-                "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')),'2015-05-01-preview').key1)]"
-            }
-        },
-        {
-            "type": "Microsoft.KeyVault/vaults/secrets",
-            "apiVersion": "2016-10-01",
-            "name": "[concat(variables('keyVaultName'), '/TenantId')]",
-            "comments": "This secret is the Tenant ID of the Teams instance.",
-            "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
-            ],
-            "properties": {
-                "attributes": {
-                    "enabled": true
-                },
-                "value": "[parameters('teamsTenantId')]"
-            }
-        },
-        {
-            "type": "Microsoft.KeyVault/vaults/secrets",
-            "apiVersion": "2016-10-01",
-            "name": "[concat(variables('keyVaultName'), '/WorkforceSuperUserName')]",
-            "comments": "This secret is the Kronos WFC Superuser name.",
-            "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
-            ],
-            "properties": {
-                "attributes": {
-                    "enabled": true
-                },
-                "value": "[parameters('kronosUserName')]"
-            }
-        },
-        {
-            "type": "Microsoft.KeyVault/vaults/secrets",
-            "apiVersion": "2016-10-01",
-            "name": "[concat(variables('keyVaultName'), '/WorkforceSuperUserPassword')]",
-            "comments": "This secret is the Kronos WFC Superuser password.",
-            "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
-            ],
-            "properties": {
-                "attributes": {
-                    "enabled": true
-                },
-                "value": "[parameters('kronosPassword')]"
-            }
-        },
-        {
-            "name": "[variables('logicAppName')]",
-            "type": "Microsoft.Logic/workflows",
-            "apiVersion": "2016-06-01",
-            "location": "[parameters('location')]",
-            "comments": "This resource defines the Azure Logic app to periodically sync data between Kronos WFC and Shifts.",
-            "tags": {
-            },
-            "scale": null,
-            "properties": {
-                "state": "Enabled",
-                "definition": {
-                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {
-                    },
-                    "actions": {
-                        "Data_Sync": {
-                            "inputs": {
-                                "authentication": {
-                                    "audience": "[variables('logicAppAudience')]",
-                                    "clientId": "[parameters('aadAppClientId')]",
-                                    "secret": "[parameters('aadAppClientSecret')]",
-                                    "tenant": "[parameters('teamsTenantId')]",
-                                    "type": "[variables('logicAppAuthenticationType')]"
-                                },
-                                "method": "GET",
-                                "uri": "[concat(variables('apiAppUrl'), '/api/SyncKronosToShifts/StartSync/true')]"
-                            },
-                            "runAfter": {
-                            },
-                            "type": "Http"
-                        }
-                    }
-                }
-            }
-        }
-    ],
-    "outputs": {
-        "outStorageAccntName": {
-            "type": "string",
-            "value": "[variables('storageAccountName')]"
-        },
-        "outApiUrl": {
-            "type": "string",
-            "value": "[variables('apiAppUrl')]"
-        },
-        "outConfigUrl": {
-            "type": "string",
-            "value": "[variables('configAppUrl')]"
-        },
-        "outHostingTenantId": {
-            "type": "string",
-            "value": "[subscription().tenantId]"
-        },
-        "outTeamsTenantId": {
-            "type": "string",
-            "value": "[parameters('teamsTenantId')]"
-        }
+    "aadAppClientSecret": {
+      "type": "securestring",
+      "minLength": 1,
+      "metadata": {
+        "description": "The Microsoft Application Password for the Shifts-Kronos Integration."
+      }
+    },
+    "managedAadAppObjectId": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "The Microsoft Application Object ID for the Shifts-Kronos Integration."
+      }
+    },
+    "teamsTenantId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36,
+      "metadata": {
+        "description": "The Microsoft Teams Tenant ID."
+      }
+    },
+    "firstTimeSyncStartDate": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 10,
+      "defaultValue": "[utcNow('d')]",
+      "metadata": {
+        "description": "The start date for the sync of all data from Kronos and should be written in the MM/DD/YYYY format."
+      }
+    },
+    "firstTimeSyncEndDate": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 10,
+      "defaultValue": "[utcNow('d')]",
+      "metadata": {
+        "description": "The start date for the sync of all data from Kronos and should be written in the MM/DD/YYYY format."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources"
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_ZRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "Storage Account type"
+      }
+    },
+    "sku": {
+      "type": "string",
+      "allowedValues": [
+        "Basic",
+        "Standard",
+        "Premium"
+      ],
+      "defaultValue": "Standard",
+      "metadata": {
+        "description": "The pricing tier for the hosting plan."
+      }
+    },
+    "planSize": {
+      "type": "string",
+      "allowedValues": [
+        "1",
+        "2",
+        "3"
+      ],
+      "defaultValue": "1",
+      "metadata": {
+        "description": "The size of the hosting plan (small, medium, or large)."
+      }
+    },
+    "processNumberOfUsersInBatch": {
+      "type": "int",
+      "defaultValue": 100,
+      "metadata": {
+        "description": "The number of users to process in a batch manner when syncing the Shifts from Kronos to Shifts."
+      }
+    },
+    "processNumberOfOrgJobsInBatch": {
+      "type": "int",
+      "defaultValue": 50,
+      "metadata": {
+        "description": "The number of Kronos Org Job Paths to process in a batch manner when syncing the Open Shifts from Kronos to Shifts."
+      }
+    },
+    "syncFromPreviousDays": {
+      "type": "int",
+      "defaultValue": 7,
+      "metadata": {
+        "description": "The number of days in the past to sync the data for the first time from Kronos to Shifts."
+      }
+    },
+    "syncToNextDays": {
+      "type": "int",
+      "defaultValue": 7,
+      "metadata": {
+        "description": "The number of days in the future to sync the data for the first time from Kronos to Shifts."
+      }
+    },
+    "futureSwapEligibilityDays": {
+      "type": "int",
+      "defaultValue": 7,
+      "metadata": {
+        "description": "The number of days in the future to query when checking swap shift eligibility."
+      }
+    },
+    "correctDateSpanForOutboundCalls": {
+      "type": "int",
+      "defaultValue": 100,
+      "metadata": {
+        "description": "This value will be able to accommodate for any requests that FLWs make for Swap Shift Requests, or Open Shift Requests in the Shifts UI."
+      }
+    },
+    "numberOfOrgJobPathSectionsForActivityName": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "This is the number of org job path sections you want to appear as a Teams shift activity name (this is only used when syncing a shift transfer)."
+      }
+    },
+    "managerTimeOffRequestCommentText": {
+      "type": "string",
+      "metadata": {
+        "description": "This is the Kronos 'comment text' value to assign to manager time off request notes. This will need to be configured in Kronos beforehand."
+      }
+    },
+    "senderTimeOffRequestCommentText": {
+      "type": "string",
+      "metadata": {
+        "description": "This is the Kronos 'comment text' value to assign to sender time off request notes. This will need to be configured in Kronos beforehand."
+      }
+    },
+    "kronosUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "Please enter the Kronos WFC SuperUser name here."
+      }
+    },
+    "kronosPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Please enter the Kronos WFC SuperUser password here."
+      }
+    },
+    "gitRepoUrl": {
+      "type": "string",
+      "defaultValue": "https://github.com/OfficeDev/Microsoft-Teams-Shifts-WFM-Connectors"
+    },
+    "gitBranch": {
+      "type": "string",
+      "defaultValue": "master"
     }
+  },
+  "variables": {
+    "authority": "https://login.microsoftonline.com/common",
+    "storageAccountName": "[uniquestring(concat(resourceGroup().id, parameters('baseResourceName')))]",
+    "hostingPlanName": "[concat('shiftsKronos', uniqueString(resourceGroup().id))]",
+    "configAppName": "[concat(parameters('baseResourceName'), '-config')]",
+    "configAppUrl": "[concat('https://', variables('configAppName'), '.azurewebsites.net')]",
+    "configAppInsightsName": "[concat(parameters('baseResourceName'), '-config')]",
+    "apiAppName": "[concat(parameters('baseResourceName'), '-api')]",
+    "apiAppUrl": "[concat('https://', variables('apiAppName'), '.azurewebsites.net')]",
+    "apiAppInsightsName": "[concat(parameters('baseResourceName'), '-api')]",
+    "sharedSkus": [
+      "Free",
+      "Shared"
+    ],
+    "isSharedPlan": "[contains(variables('sharedSkus'), parameters('sku'))]",
+    "skuFamily": "[if(equals(parameters('sku'), 'Shared'), 'D', take(parameters('sku'), 1))]",
+    "keyVaultName": "[concat(parameters('baseResourceName'), '-azureKV')]",
+    "logicAppName": "[concat(parameters('baseResourceName'), '-logicApp')]",
+    "redisCacheName": "[concat(parameters('baseResourceName'), '-redis')]",
+    "CallbackPath": "/signin-oidc",
+    "SignedOutCallbackPath ": "/signout-callback-oidc",
+    "ResponseType": "code id_token",
+    "GraphApiUrlConfig": "https://graph.microsoft.com/beta/",
+    "TemplatesContainerName": "templates",
+    "KronosUserDetailsQuery": "All Home",
+    "KronosShiftUserMappingTemplateName": "KronosShiftUserMappingTemplate.xlsx",
+    "KronosShiftTeamDeptMappingTemplateName": "KronosShiftTeamDeptMappingTemplate.xlsx",
+    "ExcelContentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "kronosQueryDateSpanFormat": "MM/dd/yyyy",
+    "logicAppAudience": "[parameters('aadAppClientId')]",
+    "logicAppAuthenticationType": "ActiveDirectoryOAuth",
+    "keyVaultUrl": "[concat('https://', variables('keyVaultName'), '.vault.azure.net/')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Cache/Redis",
+      "apiVersion": "2017-10-01",
+      "name": "[variables('redisCacheName')]",
+      "location": "[parameters('location')]",
+      "comments": "This Redis cache is used for caching the Graph API token.",
+      "properties": {
+        "sku": {
+          "name": "Standard",
+          "family": "C",
+          "capacity": 1
+        },
+        "enableNonSslPort": false,
+        "redisConfiguration": {
+          "maxclients": "1000",
+          "maxmemory-reserved": "50",
+          "maxfragmentationmemory-reserved": "50",
+          "maxmemory-delta": "50"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "comments": "This storage account is used for storing mapping information, map entities between Kronos and Shifts, and store the templates blob.",
+      "apiVersion": "2018-02-01",
+      "sku": {
+        "name": "[parameters('storageAccountType')]"
+      },
+      "kind": "StorageV2",
+      "properties": {
+      },
+      "resources": [
+        {
+          "name": "[concat('default/', variables('TemplatesContainerName'))]",
+          "type": "blobServices/containers",
+          "apiVersion": "2018-07-01",
+          "dependsOn": [
+            "[variables('storageAccountName')]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "apiVersion": "2016-09-01",
+      "name": "[variables('hostingPlanName')]",
+      "location": "[parameters('location')]",
+      "comments": "This hosting plan is used for hosting the Configuration Web app and the Integration Service API.",
+      "properties": {
+        "name": "[variables('hostingPlanName')]",
+        "hostingEnvironment": "",
+        "numberOfWorkers": 1
+      },
+      "sku": {
+        "name": "[if(variables('isSharedPlan'), concat(variables('skuFamily'),'1'), concat(variables('skuFamily'),parameters('planSize')))]",
+        "tier": "[parameters('sku')]",
+        "size": "[concat(variables('skuFamily'), parameters('planSize'))]",
+        "family": "[variables('skuFamily')]",
+        "capacity": 0
+      }
+    },
+    {
+      "type": "Microsoft.Insights/components",
+      "name": "[variables('configAppInsightsName')]",
+      "apiVersion": "2015-05-01",
+      "location": "[parameters('location')]",
+      "comments": "This ApplicationInsights resource tracks telemetry for the Configuration Web app.",
+      "kind": "",
+      "properties": {
+        "Application_Type": "web"
+      }
+    },
+    {
+      "type": "Microsoft.Insights/components",
+      "name": "[variables('apiAppInsightsName')]",
+      "apiVersion": "2015-05-01",
+      "location": "[parameters('location')]",
+      "comments": "This ApplicationInsights resource tracks telemetry for the Integration Service API.",
+      "kind": "",
+      "properties": {
+        "Application_Type": "web"
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2016-08-01",
+      "name": "[variables('configAppName')]",
+      "location": "[parameters('location')]",
+      "comments": "This Web App is the Configuration Web App.",
+      "kind": "app",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+        "[resourceId('Microsoft.Insights/components/', variables('configAppInsightsName'))]",
+        "[resourceId('Microsoft.Cache/Redis', variables('redisCacheName'))]",
+        "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
+      ],
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "name": "[variables('configAppName')]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+        "enabled": true,
+        "reserved": false,
+        "clientAffinityEnabled": true,
+        "clientCertEnabled": false,
+        "hostNamesDisabled": false,
+        "containerSize": 0,
+        "dailyMemoryTimeQuota": 0,
+        "httpsOnly": true,
+        "siteConfig": {
+          "alwaysOn": true,
+          "appSettings": [
+            {
+              "name": "DEPLOYMENT_SCRIPT",
+              "value": "Kronos-Shifts-Connector/deploy.config.cmd"
+            },
+            {
+              "name": "ASPNETCORE_DETAILEDERRORS",
+              "value": true
+            },
+            {
+              "name": "TenantId",
+              "value": "[parameters('teamsTenantId')]"
+            },
+            {
+              "name": "ClientId",
+              "value": "[parameters('aadAppClientId')]"
+            },
+            {
+              "name": "Authority",
+              "value": "[variables('authority')]"
+            },
+            {
+              "name": "CallbackPath",
+              "value": "[variables('CallbackPath')]"
+            },
+            {
+              "name": "SignedOutCallbackPath",
+              "value": "[variables('SignedOutCallbackPath ')]"
+            },
+            {
+              "name": "ClientSecret",
+              "value": "ClientSecret"
+            },
+            {
+              "name": "ResponseType",
+              "value": "[variables('ResponseType')]"
+            },
+            {
+              "name": "GraphApiUrl",
+              "value": "[variables('GraphApiUrlConfig')]"
+            },
+            {
+              "name": "StorageConnectionString",
+              "value": "StorageConnectionString"
+            },
+            {
+              "name": "RedisCacheConfiguration",
+              "value": "RedisCacheConfiguration"
+            },
+            {
+              "name": "RedisCacheInstanceName",
+              "value": "[variables('redisCacheName')]"
+            },
+            {
+              "name": "IntegrationApiUrl",
+              "value": "[variables('apiAppUrl')]"
+            },
+            {
+              "name": "BaseAddressFirstTimeSync",
+              "value": "[concat(variables('apiAppUrl'), '/')]"
+            },
+            {
+              "name": "KronosUserDetailsQuery",
+              "value": "[variables('KronosUserDetailsQuery')]"
+            },
+            {
+              "name": "TemplatesContainerName",
+              "value": "[variables('TemplatesContainerName')]"
+            },
+            {
+              "name": "KronosShiftUserMappingTemplateName",
+              "value": "[variables('KronosShiftUserMappingTemplateName')]"
+            },
+            {
+              "name": "KronosShiftTeamDeptMappingTemplateName",
+              "value": "[variables('KronosShiftTeamDeptMappingTemplateName')]"
+            },
+            {
+              "name": "ExcelContentType",
+              "value": "[variables('ExcelContentType')]"
+            },
+            {
+              "name": "WfmSuperUsername",
+              "value": "WorkforceSuperUserName"
+            },
+            {
+              "name": "WfmSuperUserPassword",
+              "value": "WorkforceSuperUserPassword"
+            },
+            {
+              "name": "KeyVault",
+              "value": "[variables('keyVaultUrl')]"
+            },
+            {
+              "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+              "value": "[reference(resourceId('Microsoft.Insights/components/', variables('configAppInsightsName')), '2015-05-01').InstrumentationKey]"
+            },
+            {
+              "name": "principalId",
+              "value": "[parameters('managedAadAppObjectId')]"
+            }
+          ]
+        }
+      },
+      "resources": [
+        {
+          "apiVersion": "2020-12-01",
+          "name": "web",
+          "type": "sourcecontrols",
+          "dependsOn": [
+            "[concat('Microsoft.Web/sites/', variables('configAppName'))]"
+          ],
+          "properties": {
+            "RepoUrl": "[parameters('gitRepoUrl')]",
+            "branch": "[parameters('gitBranch')]",
+            "IsManualIntegration": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2016-08-01",
+      "name": "[variables('apiAppName')]",
+      "location": "[parameters('location')]",
+      "comments": "This Web app is for the Integration Service API.",
+      "kind": "app",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+        "[resourceId('Microsoft.Insights/components/', variables('apiAppInsightsName'))]",
+        "[resourceId('Microsoft.Cache/Redis', variables('redisCacheName'))]"
+      ],
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "name": "[variables('apiAppName')]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+        "enabled": true,
+        "reserved": false,
+        "clientAffinityEnabled": true,
+        "clientCertEnabled": false,
+        "hostNamesDisabled": false,
+        "containerSize": 0,
+        "dailyMemoryTimeQuota": 0,
+        "httpsOnly": true,
+        "siteConfig": {
+          "alwaysOn": true,
+          "appSettings": [
+            {
+              "name": "DEPLOYMENT_SCRIPT",
+              "value": "Kronos-Shifts-Connector/deploy.api.cmd"
+            },
+            {
+              "name": "ASPNETCORE_DETAILEDERRORS",
+              "value": true
+            },
+            {
+              "name": "GraphApiUrl",
+              "value": "https://graph.microsoft.com"
+            },
+            {
+              "name": "GraphBetaApiUrl",
+              "value": "https://graph.microsoft.com/beta/"
+            },
+            {
+              "name": "ShiftStartDate",
+              "value": "[parameters('firstTimeSyncStartDate')]"
+            },
+            {
+              "name": "ShiftEndDate",
+              "value": "[parameters('firstTimeSyncEndDate')]"
+            },
+            {
+              "name": "ShiftTheme",
+              "value": "blue"
+            },
+            {
+              "name": "OpenShiftTheme",
+              "value": "green"
+            },
+            {
+              "name": "Instance",
+              "value": "https://login.microsoftonline.com/"
+            },
+            {
+              "name": "TenantId",
+              "value": "[parameters('teamsTenantId')]"
+            },
+            {
+              "name": "KeyVault",
+              "value": "[variables('keyVaultUrl')]"
+            },
+            {
+              "name": "ProcessNumberOfUsersInBatch",
+              "value": "[parameters('processNumberOfUsersInBatch')]"
+            },
+            {
+              "name": "ProcessNumberOfOrgJobsInBatch",
+              "value": "[parameters('processNumberOfOrgJobsInBatch')]"
+            },
+            {
+              "name": "ShiftEntityMapping",
+              "value": "ShiftEntityMapping"
+            },
+            {
+              "name": "SwapShiftEntityMapping",
+              "value": "SwapShiftEntityMapping"
+            },
+            {
+              "name": "TeamDepartmentMapping",
+              "value": "TeamToDepartmentWithJobMapping"
+            },
+            {
+              "name": "UserToUserMapping",
+              "value": "UserToUserMapping"
+            },
+            {
+              "name": "WfmSuperUsername",
+              "value": "WorkforceSuperUserName"
+            },
+            {
+              "name": "WfmSuperUserPassword",
+              "value": "WorkforceSuperUserPassword"
+            },
+            {
+              "name": "ClientSecret",
+              "value": "ClientSecret"
+            },
+            {
+              "name": "StorageConnectionString",
+              "value": "StorageConnectionString"
+            },
+            {
+              "name": "RedisCacheConfiguration",
+              "value": "RedisCacheConfiguration"
+            },
+            {
+              "name": "RedisCacheInstanceName",
+              "value": "[variables('redisCacheName')]"
+            },
+            {
+              "name": "SyncFromPreviousDays",
+              "value": "[parameters('syncFromPreviousDays')]"
+            },
+            {
+              "name": "SyncToNextDays",
+              "value": "[parameters('syncToNextDays')]"
+            },
+            {
+              "name": "FutureSwapEligibilityDays",
+              "value": "[parameters('futureSwapEligibilityDays')]"
+            },
+            {
+              "name": "SyncDelayForPolling",
+              "value": 0
+            },
+            {
+              "name": "KronosQueryDateSpanFormat",
+              "value": "[variables('kronosQueryDateSpanFormat')]"
+            },
+            {
+              "name": "NumberOfOrgJobPathSectionsForActivityName",
+              "value": "[parameters('numberOfOrgJobPathSectionsForActivityName')]"
+            },
+            {
+              "name": "ManagerTimeOffRequestCommentText",
+              "value": "[parameters('managerTimeOffRequestCommentText')]"
+            },
+            {
+              "name": "SenderTimeOffRequestCommentText",
+              "value": "[parameters('senderTimeOffRequestCommentText')]"
+            },
+            {
+              "name": "BaseAddressFirstTimeSync",
+              "value": "[variables('apiAppUrl')]"
+            },
+            {
+              "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+              "value": "[reference(resourceId('Microsoft.Insights/components/', variables('apiAppInsightsName')), '2015-05-01').InstrumentationKey]"
+            },
+            {
+              "name": "principalId",
+              "value": "[parameters('managedAadAppObjectId')]"
+            },
+            {
+              "name": "CorrectedDateSpanForOutboundCalls",
+              "value": "[parameters('correctDateSpanForOutboundCalls')]"
+            },
+            {
+              "name": "ClientId",
+              "value": "[parameters('aadAppClientId')]"
+            }
+          ]
+        }
+      },
+      "resources": [
+        {
+          "apiVersion": "2020-12-01",
+          "name": "web",
+          "type": "sourcecontrols",
+          "dependsOn": [
+            "[concat('Microsoft.Web/sites/', variables('apiAppName'))]"
+          ],
+          "properties": {
+            "RepoUrl": "[parameters('gitRepoUrl')]",
+            "branch": "[parameters('gitBranch')]",
+            "IsManualIntegration": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2018-02-14",
+      "name": "[variables('keyVaultName')]",
+      "location": "[parameters('location')]",
+      "comments": "This Azure KeyVault will store the necessary information like the Kronos credentials, etc.",
+      "dependsOn": [
+        "[concat('Microsoft.Web/sites/', variables('apiAppName'))]",
+        "[concat('Microsoft.Web/sites/', variables('configAppName'))]"
+      ],
+      "tags": {
+        "displayName": "KeyVault"
+      },
+      "properties": {
+        "enabledForDeployment": "false",
+        "enabledForTemplateDeployment": "false",
+        "enabledForDiskEncryption": "false",
+        "tenantId": "[subscription().tenantId]",
+        "accessPolicies": [
+          {
+            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('apiAppName')), '2018-02-01', 'Full').identity.principalId]",
+            "tenantId": "[subscription().tenantId]",
+            "permissions": {
+              "secrets": [
+                "get"
+              ]
+            }
+          },
+          {
+            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('configAppName')), '2018-02-01', 'Full').identity.principalId]",
+            "tenantId": "[subscription().tenantId]",
+            "permissions": {
+              "secrets": [
+                "get",
+                "delete",
+                "set"
+              ]
+            }
+          }
+        ],
+        "sku": {
+          "name": "Standard",
+          "family": "A"
+        },
+        "networkAcls": {
+          "value": {
+            "defaultAction": "Allow",
+            "bypass": "AzureServices"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2016-10-01",
+      "name": "[concat(variables('keyVaultName'), '/ClientId')]",
+      "comments": "This secret is for the ClientID, or the Azure AD Application ID.",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+      ],
+      "properties": {
+        "attributes": {
+          "enabled": true
+        },
+        "value": "[parameters('aadAppClientId')]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2016-10-01",
+      "name": "[concat(variables('keyVaultName'), '/ClientSecret')]",
+      "comments": "This secret is for the ClientSecret which is for the Azure AD Application Registration.",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+      ],
+      "properties": {
+        "attributes": {
+          "enabled": true
+        },
+        "value": "[parameters('aadAppClientSecret')]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2016-10-01",
+      "name": "[concat(variables('keyVaultName'), '/RedisCacheConfiguration')]",
+      "comments": "This secret is for the Redis Cache configuration.",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+      ],
+      "properties": {
+        "attributes": {
+          "enabled": true
+        },
+        "value": "[concat(variables('redisCacheName'),'.redis.cache.windows.net,abortConnect=false,ssl=true,password=', listKeys(resourceId('Microsoft.Cache/Redis', variables('redisCacheName')), '2015-08-01').primaryKey)]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2016-10-01",
+      "name": "[concat(variables('keyVaultName'), '/StorageConnectionString')]",
+      "comments": "This secret is the Azure Table storage connection string.",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+      ],
+      "properties": {
+        "attributes": {
+          "enabled": true
+        },
+        "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')),'2015-05-01-preview').key1)]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2016-10-01",
+      "name": "[concat(variables('keyVaultName'), '/TenantId')]",
+      "comments": "This secret is the Tenant ID of the Teams instance.",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+      ],
+      "properties": {
+        "attributes": {
+          "enabled": true
+        },
+        "value": "[parameters('teamsTenantId')]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2016-10-01",
+      "name": "[concat(variables('keyVaultName'), '/WorkforceSuperUserName')]",
+      "comments": "This secret is the Kronos WFC Superuser name.",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+      ],
+      "properties": {
+        "attributes": {
+          "enabled": true
+        },
+        "value": "[parameters('kronosUserName')]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2016-10-01",
+      "name": "[concat(variables('keyVaultName'), '/WorkforceSuperUserPassword')]",
+      "comments": "This secret is the Kronos WFC Superuser password.",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+      ],
+      "properties": {
+        "attributes": {
+          "enabled": true
+        },
+        "value": "[parameters('kronosPassword')]"
+      }
+    },
+    {
+      "name": "[variables('logicAppName')]",
+      "type": "Microsoft.Logic/workflows",
+      "apiVersion": "2016-06-01",
+      "location": "[parameters('location')]",
+      "comments": "This resource defines the Azure Logic app to periodically sync data between Kronos WFC and Shifts.",
+      "tags": {
+      },
+      "scale": null,
+      "properties": {
+        "state": "Enabled",
+        "definition": {
+          "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+          },
+          "actions": {
+            "Data_Sync": {
+              "inputs": {
+                "authentication": {
+                  "audience": "[variables('logicAppAudience')]",
+                  "clientId": "[parameters('aadAppClientId')]",
+                  "secret": "[parameters('aadAppClientSecret')]",
+                  "tenant": "[parameters('teamsTenantId')]",
+                  "type": "[variables('logicAppAuthenticationType')]"
+                },
+                "method": "GET",
+                "uri": "[concat(variables('apiAppUrl'), '/api/SyncKronosToShifts/StartSync/true')]"
+              },
+              "runAfter": {
+              },
+              "type": "Http"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "outStorageAccntName": {
+      "type": "string",
+      "value": "[variables('storageAccountName')]"
+    },
+    "outApiUrl": {
+      "type": "string",
+      "value": "[variables('apiAppUrl')]"
+    },
+    "outConfigUrl": {
+      "type": "string",
+      "value": "[variables('configAppUrl')]"
+    },
+    "outHostingTenantId": {
+      "type": "string",
+      "value": "[subscription().tenantId]"
+    },
+    "outTeamsTenantId": {
+      "type": "string",
+      "value": "[parameters('teamsTenantId')]"
+    }
+  }
 }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.Models/ResponseEntities/Shifts/UpcomingShifts/ShiftSegment.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.Models/ResponseEntities/Shifts/UpcomingShifts/ShiftSegment.cs
@@ -18,6 +18,12 @@ namespace Microsoft.Teams.App.KronosWfc.Models.ResponseEntities.Shifts.UpcomingS
         public string SegmentTypeName { get; set; }
 
         /// <summary>
+        /// Gets or sets the OrgJobPath.
+        /// </summary>
+        [XmlAttribute]
+        public string OrgJobPath { get; set; }
+
+        /// <summary>
         /// Gets or sets the StartDate.
         /// </summary>
         [XmlAttribute]

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Common/AppSettings.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Common/AppSettings.cs
@@ -192,6 +192,11 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
         public string KronosQueryDateSpanFormat => this.configuration["KronosQueryDateSpanFormat"];
 
         /// <summary>
+        /// Gets the number of org job path section sto use as the activity display name.
+        /// </summary>
+        public string NumberOfOrgJobPathSectionsForActivityName => this.configuration["NumberOfOrgJobPathSectionsForActivityName"];
+
+        /// <summary>
         /// Gets the manager time off request comment text value.
         /// </summary>
         public string ManagerTimeOffRequestCommentText => this.configuration["ManagerTimeOffRequestCommentText"];

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
@@ -362,7 +362,11 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
                     // Number of elements to take from the split org job path array.
                     var numberOfOrgJobPathSections = int.Parse(this.appSettings.NumberOfOrgJobPathSectionsForActivityName, CultureInfo.InvariantCulture);
-                    var orgJobPathSections = new List<string>();
+
+                    // Ensure that the max number of sections is less than or equal to total number of sections.
+                    numberOfOrgJobPathSections = numberOfOrgJobPathSections <= splitOrgJobPath.Length ? numberOfOrgJobPathSections : splitOrgJobPath.Length;
+
+                    var orgJobPathSections = new List<string>(numberOfOrgJobPathSections);
 
                     for (int i = splitOrgJobPath.Length - numberOfOrgJobPathSections; i < splitOrgJobPath.Length; i++)
                     {
@@ -370,6 +374,14 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                     }
 
                     activityDisplayName = string.Join("-", orgJobPathSections);
+
+                    // Teams UI has a character limit of 50 so if we exceed this we want to trim the string down
+                    // and prepend an elipses to indicate we have trimmed.
+                    if (activityDisplayName.Length > 50)
+                    {
+                        var trimmedDisplayName = activityDisplayName.Substring(activityDisplayName.Length - 47);
+                        activityDisplayName = trimmedDisplayName.Insert(0, "...");
+                    }
                 }
 
                 shiftActivity.Add(new ShiftActivity

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
     using Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers;
     using Newtonsoft.Json;
     using IntegrationApi = Microsoft.Teams.Shifts.Integration.API.Models.IntegrationAPI;
+    using App.KronosWfc.Models.ResponseEntities.Shifts.UpcomingShifts;
 
     /// <summary>
     /// Shift controller.
@@ -285,9 +286,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             string monthPartitionKey)
         {
             this.telemetryClient.TrackTrace($"ShiftController - ProcessShiftEntitiesBatchAsync started at: {DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)}");
-            var shiftDisplayName = string.Empty;
             var shiftNotes = string.Empty;
-            var shiftTheme = this.appSettings.ShiftTheme;
 
             // This foreach loop processes each user in the batch.
             foreach (var user in processKronosUsersQueueInBatch)
@@ -298,36 +297,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                     if (user.KronosPersonNumber == kronosShift.Employee.FirstOrDefault().PersonNumber)
                     {
                         this.telemetryClient.TrackTrace($"ShiftController - Processing the shifts for user: {user.KronosPersonNumber}");
-                        List<ShiftActivity> shiftActivity = new List<ShiftActivity>();
 
-                        // This foreach loop will create the necessary Shift Activities
-                        // based on the Shift Segments that are retrieved from Kronos.
-                        foreach (var activity in kronosShift?.ShiftSegments)
-                        {
-                            shiftActivity.Add(new ShiftActivity
-                            {
-                                IsPaid = true,
-                                StartDateTime = this.utility.CalculateStartDateTime(activity, user.KronosTimeZone),
-                                EndDateTime = this.utility.CalculateEndDateTime(activity, user.KronosTimeZone),
-                                Code = string.Empty,
-                                DisplayName = activity.SegmentTypeName,
-                            });
-                        }
-
-                        var shift = new Shift
-                        {
-                            UserId = user.ShiftUserId,
-                            SchedulingGroupId = user.ShiftScheduleGroupId,
-                            SharedShift = new SharedShift
-                            {
-                                DisplayName = shiftDisplayName,
-                                Notes = this.utility.GetShiftNotes(kronosShift),
-                                StartDateTime = shiftActivity[0].StartDateTime,
-                                EndDateTime = shiftActivity[shiftActivity.Count - 1].EndDateTime,
-                                Theme = shiftTheme,
-                                Activities = shiftActivity,
-                            },
-                        };
+                        var shift = this.GenerateTeamsShiftObject(user, kronosShift);
 
                         shift.KronosUniqueId = this.utility.CreateUniqueId(shift, user.KronosTimeZone);
 
@@ -366,6 +337,77 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             await this.CreateEntryShiftsEntityMappingAsync(configurationDetails, userModelNotFoundList, shiftsNotFoundList, monthPartitionKey).ConfigureAwait(false);
 
             this.telemetryClient.TrackTrace($"ShiftController - ProcessShiftEntitiesBatchAsync ended at: {DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)}");
+        }
+
+        /// <summary>
+        /// Creates a Teams shift object for each shift
+        /// </summary>
+        /// <param name="user">the user details the shift is assigned to.</param>
+        /// <param name="kronosShift">The shift to create a Teams shift from.</param>
+        /// <returns>A Teams shift object.</returns>
+        private Shift GenerateTeamsShiftObject(UserDetailsModel user, ScheduleShift kronosShift)
+        {
+            List<ShiftActivity> shiftActivity = new List<ShiftActivity>();
+            var shiftDisplayName = string.Empty;
+
+            foreach (var activity in kronosShift?.ShiftSegments)
+            {
+                var activityDisplayName = string.Empty;
+
+                // If there is an orgJobPath in the shift segment then this segment is working
+                // a job other than the employees main job (shift transfer)
+                if (activity.OrgJobPath != null)
+                {
+                    var splitOrgJobPath = activity.OrgJobPath.Split("/");
+
+                    // Number of elements to take from the split org job path array.
+                    var numberOfOrgJobPathSections = int.Parse(this.appSettings.NumberOfOrgJobPathSectionsForActivityName, CultureInfo.InvariantCulture);
+                    var orgJobPathSections = new List<string>();
+
+                    for (int i = splitOrgJobPath.Length - numberOfOrgJobPathSections; i < splitOrgJobPath.Length; i++)
+                    {
+                        orgJobPathSections.Add(splitOrgJobPath[i]);
+                    }
+
+                    activityDisplayName = string.Join("-", orgJobPathSections);
+                }
+
+                shiftActivity.Add(new ShiftActivity
+                {
+                    IsPaid = true,
+                    StartDateTime = this.utility.CalculateStartDateTime(activity, user.KronosTimeZone),
+                    EndDateTime = this.utility.CalculateEndDateTime(activity, user.KronosTimeZone),
+                    Code = string.Empty,
+                    DisplayName = activity.OrgJobPath != null ? activityDisplayName : activity.SegmentTypeName,
+                });
+            }
+
+            var displayNameStartTime = DateTime.Parse(kronosShift.ShiftSegments.First().StartTime, CultureInfo.InvariantCulture);
+            var displayNameEndTime = DateTime.Parse(kronosShift.ShiftSegments.Last().EndTime, CultureInfo.InvariantCulture);
+
+            // We want to make it clear in the shift label/display name that this is a transferred shift.
+            if (kronosShift.ShiftSegments.Any(x => x.SegmentTypeName == "TRANSFER"))
+            {
+                var displayNameTime = $"{displayNameStartTime.ToString("HH:mm", CultureInfo.InvariantCulture)} - {displayNameEndTime.ToString("HH:mm", CultureInfo.InvariantCulture)}";
+                shiftDisplayName = $"TRANSFER {displayNameTime}";
+            }
+
+            var shift = new Shift
+            {
+                UserId = user.ShiftUserId,
+                SchedulingGroupId = user.ShiftScheduleGroupId,
+                SharedShift = new SharedShift
+                {
+                    DisplayName = shiftDisplayName,
+                    Notes = this.utility.GetShiftNotes(kronosShift),
+                    StartDateTime = shiftActivity[0].StartDateTime,
+                    EndDateTime = shiftActivity[shiftActivity.Count - 1].EndDateTime,
+                    Theme = this.appSettings.ShiftTheme,
+                    Activities = shiftActivity,
+                },
+            };
+
+            return shift;
         }
 
         /// <summary>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/appsettings.json
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/appsettings.json
@@ -42,6 +42,7 @@
   "KronosQueryDateSpanFormat": "M/dd/yyyy",
   "BaseAddressFirstTimeSync": "https://kronos-shift-api-test.azurewebsites.net/",
   "CorrectedDateSpanForOutboundCalls": 100,
+  "NumberOfOrgJobPathSectionsForActivityName": 2,
   "ManagerTimeOffRequestCommentText": "Manager TOR Notes",
   "SenderTimeOffRequestCommentText": "Employee TOR Notes"
 }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/appsettings.json
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/appsettings.json
@@ -42,7 +42,7 @@
   "KronosQueryDateSpanFormat": "M/dd/yyyy",
   "BaseAddressFirstTimeSync": "https://kronos-shift-api-test.azurewebsites.net/",
   "CorrectedDateSpanForOutboundCalls": 100,
-  "NumberOfOrgJobPathSectionsForActivityName": 2,
+  "NumberOfOrgJobPathSectionsForActivityName": 5,
   "ManagerTimeOffRequestCommentText": "Manager TOR Notes",
   "SenderTimeOffRequestCommentText": "Employee TOR Notes"
 }

--- a/Kronos-Shifts-Connector/README.md
+++ b/Kronos-Shifts-Connector/README.md
@@ -54,6 +54,7 @@ To begin with, you will need to ensure following perequisites:
 * Kronos WFC endpoint
 * SuperUser Name
 * SuperUser password  
+* You will also need to be aware of the Kronos session timeout value as we use this when caching the session token  
 Review and ensure users, org levels and jobs are properly setup in Kronos system
 
 2. Microsoft Teams Shifts App - Access to Teams Deployment with Shifts App
@@ -68,6 +69,21 @@ Review and ensure AAD users, Teams, and Scheduling Groups are properly setup in 
 * Azure Blob storage
 * Azure Key Value
 * Application Insights
+
+#### Configuration to Enable Syncing of Notes
+Kronos requires a **Comment Text** value to be assigned to any comments or notes. This requires you to firstly configure each comment text before adding the chosen values in to the connector appSettings - this will be done when we deploy using the ARM template.
+
+The following settings you must configure are:
+   - **SenderTimeOffRequestCommentText** - Used for syncing time off request notes added by the requestor.
+   - **ManagerTimeOffRequestCommentText** - Used for syncing time off request notes added by the manager. (Please note we do not currently support manager TOR note syncing, however plan to in the near future).
+
+1. First Log in to Kronos as an admin and navigate to the Comments section under Setup -> CommonSetup.
+![Comment Setup Screen](images/figure53.png)
+
+2. Now click the **New** button to configure a new comment type. Add the value you want the comment text to be - this can be whatever you like. Next set a code number - again this is up to you. Finally ensure that you select the correct categories for the comment you are setting up and hit **Save**.
+![Adding a New Comment Screen](images/figure54.png)
+
+3. Repeat this for all of the comment types listed above.
 
 ### Register Azure AD Application
 This integration app uses [Microsoft Graph APIs](https://developer.microsoft.com/en-us/graph) to access users (FLWs & FLMs) and teams and their schedules from Microsoft Teams Shifts App. To use Microsoft Graph to read and write resources on behalf of a user, this integration app needs to be registered in Azure AD by following steps below.  This is required to use Microsoft identity platform endpoint for authentication and authorization with Microsoft Graph.
@@ -153,7 +169,11 @@ Here are the following requirements to correctly deploy the **Shifts-Kronos Inte
 |processNumberOfOrgJobsInBatch|When syncing the open shift entities between Kronos and Shifts App, the transfer is done based on the org job paths in a batch manner. The default value is 50 and can be changed at the time of deployment|
 |syncFromPreviousDays|The number of days in the past for subsequent syncs between Kronos and Shifts App|
 |syncToNextDays|The number of days in the future for subsequent syncs between Kronos and Shifts App|
+|futureSwapEligibilityDays|The number of days in the future to query when checking swap shift eligibility|
 |correctDateSpanForOutboundCalls|The number of days in the past and future when it comes to having outbound calls for the Open Shift and Swap Shift Requests|
+|numberOfOrgJobPathSectionsForActivityName|This is the number of org job path sections you want to appear as a Teams shift activity name (this is only used when syncing a shift transfer). <br /> Example: ./Contoso/UK/Stores/London/Checkout/Checkout Operator <br /> - A value of 2 would lead to shift transfer activites having a title of: _Checkout - Checkout Operator_ <br /> - A value of 1 would lead to shift transfer activites having a title of: _Checkout Operator_|
+|managerTimeOffRequestCommentText|Used for syncing time off request notes added by the manager. (Please note we do not currently support manager TOR note syncing, however plan to in the near future)|
+|senderTimeOffRequestCommentText|Used for syncing time off request notes added by the requestor|
 |kronosUserName|The Kronos WFC SuperUser name|
 |kronosPassword|The Kronos WFC SuperUser password|
 |gitRepoUrl|The public GitHub repository URL|
@@ -517,28 +537,6 @@ In the current version of the connector, it is necessary to make the following C
     	3. **TOR** (for Time Off Requests)
 3. When submitting shift swap requests the connector uses a specific comment type which must be created in Kronos with the name **Other reason**
 
-#### Configuration to Enable Syncing of Notes
-Kronos requires a **Comment Text** value to be assigned to any comments or notes. This requires you to firstly configure each comment text before adding the chosen values in to the connector appSettings.
-
-The following settings you must configure are:
-   - **SenderTimeOffRequestCommentText** - Used for syncing time off request notes added by the requestor.
-   - **ManagerTimeOffRequestCommentText** - Used for syncing time off request notes added by the manager. (Please note we do not currently support manager TOR note syncing, however plan to in the near future).
-
-1. First Log in to Kronos as an admin and navigate to the Comments section under Setup -> CommonSetup.
-![Comment Setup Screen](images/figure53.png)
-
-2. Now click the **New** button to configure a new comment type. Add the value you want the comment text to be - this can be whatever you like. Next set a code number - again this is up to you. Finally ensure that you select the correct categories for the comment you are setting up and hit **Save**.
-![Adding a New Comment Screen](images/figure54.png)
-
-3. Repeat this for all of the comment types listed above.
-
-4. Finally you need to add each of the **CommentText** values you created to the connector app settings. Please go to your Azure resource group and select the integration api app service (not config app service).
-
-5. Next on the left hand side under Setting, select **Configuration**.
-
-6. You now want to add the **Comment Text** values you just created in Kronos for each of the settings listed above. You can do this by clicking edit and changing the value.
-
-7. Once you have added all of the values remember to click save at the top of the page.
 ### Step 5: Perform first time sync
 
 Click on the Done button in Team to Department Mapping screen, which will initiate following workflows:  

--- a/Kronos-Shifts-Connector/README.md
+++ b/Kronos-Shifts-Connector/README.md
@@ -78,10 +78,10 @@ The following settings you must configure are:
    - **ManagerTimeOffRequestCommentText** - Used for syncing time off request notes added by the manager. (Please note we do not currently support manager TOR note syncing, however plan to in the near future).
 
 1. First Log in to Kronos as an admin and navigate to the Comments section under Setup -> CommonSetup.
-![Comment Setup Screen](images/figure53.png)
+![Comment Setup Screen](images/figure53.PNG)
 
 2. Now click the **New** button to configure a new comment type. Add the value you want the comment text to be - this can be whatever you like. Next set a code number - again this is up to you. Finally ensure that you select the correct categories for the comment you are setting up and hit **Save**.
-![Adding a New Comment Screen](images/figure54.png)
+![Adding a New Comment Screen](images/figure54.PNG)
 
 3. Repeat this for all of the comment types listed above.
 

--- a/Kronos-Shifts-Connector/README.md
+++ b/Kronos-Shifts-Connector/README.md
@@ -171,7 +171,7 @@ Here are the following requirements to correctly deploy the **Shifts-Kronos Inte
 |syncToNextDays|The number of days in the future for subsequent syncs between Kronos and Shifts App|
 |futureSwapEligibilityDays|The number of days in the future to query when checking swap shift eligibility|
 |correctDateSpanForOutboundCalls|The number of days in the past and future when it comes to having outbound calls for the Open Shift and Swap Shift Requests|
-|numberOfOrgJobPathSectionsForActivityName|This is the number of org job path sections you want to appear as a Teams shift activity name (this is only used when syncing a shift transfer). <br /> Example: ./Contoso/UK/Stores/London/Checkout/Checkout Operator <br /> - A value of 2 would lead to shift transfer activites having a title of: _Checkout - Checkout Operator_ <br /> - A value of 1 would lead to shift transfer activites having a title of: _Checkout Operator_|
+|numberOfOrgJobPathSectionsForActivityName|This is the number of org job path sections you want to appear as a Teams shift activity name (this is only used when syncing a shift transfer). <br /> Example: ./Contoso/UK/Stores/London/Checkout/Checkout Operator <br /> - A value of 2 would lead to shift transfer activities having a title of: _Checkout - Checkout Operator_ <br /> - A value of 1 would lead to shift transfer activities having a title of: _Checkout Operator_|
 |managerTimeOffRequestCommentText|Used for syncing time off request notes added by the manager. (Please note we do not currently support manager TOR note syncing, however plan to in the near future)|
 |senderTimeOffRequestCommentText|Used for syncing time off request notes added by the requestor|
 |kronosUserName|The Kronos WFC SuperUser name|


### PR DESCRIPTION
It was unclear to users when they were assigned a shift transfer in Teams. 

- Display that the shift contains a transfer using the Teams shift label.
- Updated the way we sync activities to include the org job path.
- Added a config value to allow the customer to configure how many parts of the org job path they want to display as the activity title.
- Updated the ARM template to include parameters for the new config value as well as for previously missed values.
- Updated readme